### PR TITLE
Using environment variables and adding CLI to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ You should have Docker installed on your machine. To get started, you will need 
 
 If you are interested in learning about specific `mltrace` concepts, please read [this page](https://mltrace.readthedocs.io/en/latest/concepts.html) in the official docs.
 
-### Database and server setup
+### Database setup (server-side)
 
 We use Postgres-backed SQLAlchemy. Assuming you have Docker installed, you can run the following commands from the
-root directory:
+root directory after cloning the most recent release:
 
 ```
 docker-compose build
@@ -40,7 +40,7 @@ docker-compose up [-d]
 
 And then to tear down the containers, you can run `docker-compose down`.
 
-### Run pipelines
+### Run pipelines (client-side)
 
 To use the logging functions in dev mode, you will need to install various dependencies:
 
@@ -48,6 +48,14 @@ To use the logging functions in dev mode, you will need to install various depen
 pip install -r requirements.txt
 pip install -e .
 ```
+
+Next, you will need to set the database URI. It is recommended to use environment variables for this. To set the database address, set the `DB_SERVER` variable:
+
+```
+export DB_SERVER=<SERVER'S IP ADDRESS>
+```
+
+where `<SERVER'S IP ADDRESS>` is either the IP address of a remote machine or `localhost` if running locally. If, when you set up the server, you changed the URI in `docker-compose.yaml`, you can set the `DB_URI` variable (which represents the entire database URI) client-side instead of `DB_SERVER`.
 
 The files in the `examples` folder contain sample scripts you can run. For instance, if you run `examples/industry_ml.py`, you might get an output like:
 
@@ -63,7 +71,7 @@ And if you trace this output in the UI (`trace zguzvnwsux`), you will get:
 
 You can also look at `examples` for ways to integrate `mltrace` into your ML pipelines, or check out the [official documentation](https://mltrace.readthedocs.io/en/latest/).
 
-### Launch UI
+### Launch UI (client-side)
 
 If you ran `docker-compose up` from the root directory, you can just navigate to the server's IP address at port 8080 (or `localhost:8080`) in your browser. To launch a dev version of the UI, navigate to `./mltrace/server/ui` and execute `yarn install` then `yarn start`. It should be served at [localhost:3000](localhost:3000). The UI is based on `create-react-app` and [`blueprintjs`](https://blueprintjs.com/docs/). Here's an example of what tracing an output would give:
 
@@ -78,6 +86,16 @@ If you ran `docker-compose up` from the root directory, you can just navigate to
 | `inspect COMPONENT_RUN_ID` | Shows info for that component run ID |
 | `trace OUTPUT_ID` | Shows a trace of steps for the output ID |
 | `tag TAG_NAME` | Shows all components with the tag name|
+
+### Using the CLI for querying
+
+The following commands are supported via CLI:
+
+- `history`
+- `recent`
+- `trace`
+
+You can execute `mltrace --help` in your shell for usage instructions, or you can execute `mltrace command --help` for usage instructions for a specific command.
 
 ### Future directions
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       dockerfile: ./mltrace/server/Dockerfile
     environment:
       PYTHONPATH: /src
+      DB_URI: "postgresql://admin:admin@database:5432/sqlalchemy"
     volumes:
       - .:/src
     ports:

--- a/docs/source/logging.rst
+++ b/docs/source/logging.rst
@@ -9,14 +9,13 @@ Logging
 
     pip install mltrace
 
-For this example, we will add logging functions to a hypothetical ``cleaning.py`` that loads raw data and cleans it. In your Python file, before you call any logging functions, you will need to make sure you are connected to your server. To do so, include the following code snippet at the beginning of your file:
+For this example, we will add logging functions to a hypothetical ``cleaning.py`` that loads raw data and cleans it. In your Python file, before you call any logging functions, you will need to make sure you are connected to your server. You can easily do so by setting the environment variable ``DB_SERVER`` to your server's IP address:
 
 .. code-block :: python
 
-    import mltrace
-    mltrace.set_address(SERVER_IP_ADDRESS)
+    export DB_SERVER=SERVER_IP_ADDRESS
 
-where ``SERVER_IP_ADDRESS`` is your server's IP address or "localhost" if you are running locally.
+where ``SERVER_IP_ADDRESS`` is your server's IP address or "localhost" if you are running locally. You can also call ``mltrace.set_address(SERVER_IP_ADDRESS)`` in your Python script instead if you do not want to set the environment variable.
 
 Component creation
 ^^^^^^^^^^^^^^^^^^
@@ -127,7 +126,7 @@ To put it all together, here's an end to end example of ``cleaning.py``:
     """
 
     from datetime import datetime
-    from mltrace import create_component, register, set_address
+    from mltrace import create_component, register
     import pandas as pd
 
     @register(
@@ -143,8 +142,9 @@ To put it all together, here's an end to end example of ``cleaning.py``:
         return clean_version
     
     if __name__ == "__main__"::
-        # Set hostname and create component
-        set_address("localhost")
+        # Optional set hostname if you have not set DB_SERVER env var: mltrace.set_address("localhost")
+
+        # Create component
         create_component(
             name="cleaning",
             description="Removes records with data out of bounds",

--- a/docs/source/querying.rst
+++ b/docs/source/querying.rst
@@ -28,6 +28,16 @@ You can toggle between light and dark mode using the moon or sun button at the t
 | ``tag``     | Displays all components with the given tag name.                                                                                                                                              | ``tag TAG_NAME``              |
 +-------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------+
 
+Using the CLI
+^^^^^^^^^^^^
+
+The following commands are supported via CLI:
+
+- :py:func:`~mltrace.cli.cli.history`
+- :py:func:`~mltrace.cli.cli.recent`
+- :py:func:`~mltrace.cli.cli.trace`
+
+You can execute ``mltrace --help`` in your shell for usage instructions, or you can execute ``mltrace command --help`` for usage instructions for a specific command.
 
 :py:mod:`mltrace` module functions
 ^^^^^^^^^^^^^^^^^^

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -24,7 +24,7 @@ On the machine you would like to run the server (can be your local machine), clo
     docker-compose build
     docker-compose up [-d]
 
-You can access the UI by navigating to ``<server_ip_address>:8080`` (or localhost:8080_ if you are running locally) in your browser. 
+You can access the UI by navigating to ``<SERVER'S IP ADDRESS>:8080`` (or localhost:8080_ if you are running locally) in your browser. 
 
 .. _mltrace: https://github.com/loglabs/mltrace/tree/v0.13
 .. _localhost:8080: http://localhost:8080
@@ -37,4 +37,12 @@ To log to the server using the client library, install the latest version of mlt
 .. code-block:: python
 
     pip install mltrace
+
+Next, you will need to set the database URI. It is recommended to use environment variables for this. To set the database address, set the ``DB_SERVER`` variable:
+
+.. code-block :: python
+
+    export DB_SERVER=<SERVER'S IP ADDRESS>
+
+where ``<SERVER'S IP ADDRESS>`` is either the IP address of a remote machine or ``localhost`` if running locally. If, when you set up the server, you changed the URI in ``docker-compose.yaml``, you can set the ``DB_URI`` variable (which represents the entire database URI) client-side instead of ``DB_SERVER``.
 

--- a/examples/industry_ml.py
+++ b/examples/industry_ml.py
@@ -13,13 +13,7 @@ The code in each of these components is placeholder code. When you run this file
 """
 
 
-from mltrace import (
-    create_component,
-    register,
-    set_address,
-    clean_db,
-    get_components_with_tag,
-)
+from mltrace import create_component, register
 
 import random
 import string
@@ -89,9 +83,6 @@ def inference(filename: str, model_path: str) -> str:
 
 
 if __name__ == "__main__":
-    # Set server
-    set_address("localhost")
-
     # Create components
     create_component(
         name="ingest",

--- a/examples/research_ml.py
+++ b/examples/research_ml.py
@@ -8,7 +8,7 @@ If you navigate to the UI and run `history research_model_development`, you will
 However, using something like wandb or mlflow might be better for research. This is because mltrace inputs and outputs are not stored as key/value pairs; only the values are stored.
 """
 
-from mltrace import create_component, register, set_address
+from mltrace import create_component, register
 
 import itertools
 import random
@@ -27,8 +27,6 @@ def train_and_evaluate_model(lr, num_epochs, hidden_size):
 
 
 if __name__ == "__main__":
-    # Set server
-    set_address("localhost")
 
     # Create component
     create_component(

--- a/examples/tiny.py
+++ b/examples/tiny.py
@@ -5,7 +5,7 @@ This file contains one component, a function to increment a number, and runs tha
 """
 
 
-from mltrace import create_component, register, set_address
+from mltrace import create_component, register
 
 import random
 import string
@@ -21,9 +21,6 @@ def increment(inp: int) -> int:
 
 
 if __name__ == "__main__":
-    # Set server
-    set_address("localhost")
-
     # Create component
     create_component(
         name="tiny",

--- a/mltrace/cli/cli.py
+++ b/mltrace/cli/cli.py
@@ -16,16 +16,6 @@ import textwrap
 # ------------------------- Utilities ------------------------ #
 
 
-def set_server(url: str):
-    """
-    Set the database server connection.
-
-    Args:
-        url: The db url.
-    """
-    set_address(url)
-
-
 def show_info_card(run_id: int):
     """
     Prints the info cards corresponding to run ids.
@@ -165,16 +155,14 @@ def mltrace():
 
 @mltrace.command("recent")
 @click.option("--count", default=5, help="Count of recent objects.")
-@click.argument("url")
-def recent(
-    url: str,
-    count: int,
-):
+@click.option("--address", help="Database server address")
+def recent(count: int, address: str = ""):
     """
     CLI for recent objects.
     """
-    # Set Server
-    set_server(url)
+    # Set address
+    if address and len(address) > 0:
+        set_address(address)
     # Get the recent ids
     component_run_ids = get_recent_run_ids()
     for id in component_run_ids[:count]:
@@ -184,17 +172,14 @@ def recent(
 @mltrace.command("history")
 @click.argument("component_name")
 @click.option("--count", default=5, help="Count of recent objects.")
-@click.argument("url")
-def history(
-    url: str,
-    component_name: str,
-    count: int,
-):
+@click.option("--address", help="Database server address")
+def history(component_name: str, count: int, address: str = ""):
     """
     CLI for history of ComponentName.
     """
-    # Set Server
-    set_server(url)
+    # Set address
+    if address and len(address) > 0:
+        set_address(address)
     history = (
         get_history(component_name, count) if count else get_history(component_name)
     )
@@ -204,15 +189,14 @@ def history(
 @mltrace.command("trace")
 @click.argument("output_id")
 @click.argument("url")
-def trace(
-    url: str,
-    output_id: str,
-):
+@click.option("--address", help="Database server address")
+def trace(output_id: str, address: str = ""):
     """
     CLI for trace.
     """
-    # Set db
-    set_address(url)
+    # Set address
+    if address and len(address) > 0:
+        set_address(address)
     res = web_trace(output_id)
     click.echo(res[0]["label"])
     if "childNodes" in res[0].keys():

--- a/mltrace/client.py
+++ b/mltrace/client.py
@@ -7,11 +7,27 @@ import functools
 import git
 import inspect
 import logging
+import os
 import sys
 import typing
 import uuid
 
-_db_uri = "postgresql://admin:admin@database:5432/sqlalchemy"
+
+def _set_address_helper(old_uri: str, address: str):
+    first = old_uri.split("@")[0]
+    last = old_uri.split("@")[1].split(":")[1]
+    return first + "@" + address + ":" + last
+
+
+_db_uri = os.environ.get("DB_URI")
+if _db_uri is None:
+    _db_uri = "postgresql://admin:admin@localhost:5432/sqlalchemy"
+    if os.environ.get("DB_SERVER"):
+        _db_uri = _set_address_helper(_db_uri, os.environ.get("DB_SERVER"))
+    else:
+        logging.warning(
+            f"Please set DB_URI or DB_SERVER as an environment variable. Otherwise, DB_URI is set to {_db_uri}."
+        )
 
 # ----------------------- Database management functions ---------------------- #
 
@@ -28,9 +44,7 @@ def get_db_uri() -> str:
 
 def set_address(address: str):
     global _db_uri
-    first = _db_uri.split("@")[0]
-    last = _db_uri.split("@")[1].split(":")[1]
-    _db_uri = first + "@" + address + ":" + last
+    _db_uri = _set_address_helper(_db_uri, address)
 
 
 def clean_db():

--- a/mltrace/server/__init__.py
+++ b/mltrace/server/__init__.py
@@ -19,7 +19,6 @@ import logging
 
 app = Flask(__name__, static_folder="ui/build", static_url_path="")
 api = Blueprint("api", __name__)
-set_db_uri("postgresql://admin:admin@database:5432/sqlalchemy")
 
 
 def error(err_msg, status_code):


### PR DESCRIPTION
Closes #158 and closes #159. This PR:

* modifies `client.py` to use DB_ADDRESS env var
* modifies `docker-compose.yml` with env var
* modifies `cli.py` to make db address optional
* modifies documentation to include env var and CLI
* modifies examples to remove the call to `set_address`