### PR TITLE
Add first pass of diagnose function.

### DIFF
--- a/mltrace/__init__.py
+++ b/mltrace/__init__.py
@@ -21,6 +21,7 @@ from mltrace.client import (
     add_notes_to_component_run,
     flag_output_id,
     unflag_output_id,
+    diagnose_flagged_outputs,
 )
 
 __all__ = [
@@ -46,4 +47,5 @@ __all__ = [
     "add_notes_to_component_run",
     "flag_output_id",
     "unflag_output_id",
+    "diagnose_flagged_outputs",
 ]

--- a/mltrace/client.py
+++ b/mltrace/client.py
@@ -468,3 +468,12 @@ def backtrace(output_pointer: str):
 def web_trace(output_id: str):
     store = Store(_db_uri)
     return store.web_trace(output_id)
+
+
+def diagnose_flagged_outputs():
+    """Finds common ComponentRuns for a group of flagged outputs.
+    Returns a list of ComponentRuns and occurrence counts in the
+    group of flagged outputs, sorted by descending count and then
+    alphabetically."""
+    store = Store(_db_uri)
+    return store.diagnose_flagged_outputs()

--- a/mltrace/db/store.py
+++ b/mltrace/db/store.py
@@ -544,7 +544,7 @@ class Store(object):
         """Finds common ComponentRuns for a group of flagged outputs."""
         # Collate flagged outputs
         flagged_iops = (
-            self.session.query(IOPointer).filter(IOPointer.flag == True).all()
+            self.session.query(IOPointer).filter(IOPointer.flag is True).all()
         )
         flagged_output_ids = [iop.name for iop in flagged_iops]
 

--- a/mltrace/db/store.py
+++ b/mltrace/db/store.py
@@ -544,7 +544,9 @@ class Store(object):
         """Finds common ComponentRuns for a group of flagged outputs."""
         # Collate flagged outputs
         flagged_iops = (
-            self.session.query(IOPointer).filter(IOPointer.flag is True).all()
+            self.session.query(IOPointer)
+            .filter(IOPointer.flag.is_(True))
+            .all()
         )
         flagged_output_ids = [iop.name for iop in flagged_iops]
 

--- a/mltrace/db/store.py
+++ b/mltrace/db/store.py
@@ -552,11 +552,12 @@ class Store(object):
 
         # Perform traces for each output id
         traces = [self.trace(output_id) for output_id in flagged_output_ids]
+        traces = [list(set([node for _, node in trace])) for trace in traces]
 
         # Sort traces by ComponentRun count & id, descending
         trace_nodes_counts = {}
         for trace in traces:
-            for _, node in trace:
+            for node in trace:
                 if node not in trace_nodes_counts:
                     trace_nodes_counts[node] = 0
                 trace_nodes_counts[node] += 1

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -305,7 +305,85 @@ class TestStore(unittest.TestCase):
         self.assertEqual(res, expected_res)
 
     def testManyFlaggedOutputs(self):
-        pass
+        # Create components and iopointers
+        self.store.create_component(
+            "test_component_A", "test_description", "shreya"
+        )
+        self.store.create_component(
+            "test_component_B", "test_description", "shreya"
+        )
+        self.store.create_component(
+            "test_component_C", "test_description", "shreya"
+        )
+
+        iop = [self.store.get_io_pointer(f"iop_{i}") for i in range(1, 8)]
+        # Create component runs
+        # First pipeline
+        cr_A1 = self.store.initialize_empty_component_run("test_component_A")
+        cr_A1.set_start_timestamp()
+        cr_A1.set_end_timestamp()
+        cr_A1.add_outputs([iop[0], iop[1]])
+        self.store.set_dependencies_from_inputs(cr_A1)
+        self.store.commit_component_run(cr_A1)
+        cr_B1 = self.store.initialize_empty_component_run("test_component_B")
+        cr_B1.set_start_timestamp()
+        cr_B1.set_end_timestamp()
+        cr_B1.add_input(iop[0])
+        cr_B1.add_output(iop[2])
+        self.store.set_dependencies_from_inputs(cr_B1)
+        self.store.commit_component_run(cr_B1)
+        cr_C1 = self.store.initialize_empty_component_run("test_component_C")
+        cr_C1.set_start_timestamp()
+        cr_C1.set_end_timestamp()
+        cr_C1.add_inputs([iop[1], iop[2]])
+        cr_C1.add_output(iop[3])
+        self.store.set_dependencies_from_inputs(cr_C1)
+        self.store.commit_component_run(cr_C1)
+
+        # Second pipeline
+        cr_C2 = self.store.initialize_empty_component_run("test_component_C")
+        cr_C2.set_start_timestamp()
+        cr_C2.set_end_timestamp()
+        cr_C2.add_inputs([iop[1], iop[2]])
+        cr_C2.add_output(iop[4])
+        self.store.set_dependencies_from_inputs(cr_C2)
+        self.store.commit_component_run(cr_C2)
+
+        # Third pipeline
+        cr_C3 = self.store.initialize_empty_component_run("test_component_C")
+        cr_C3.set_start_timestamp()
+        cr_C3.set_end_timestamp()
+        cr_C3.add_inputs([iop[1], iop[2]])
+        cr_C3.add_output(iop[5])
+        self.store.set_dependencies_from_inputs(cr_C3)
+        self.store.commit_component_run(cr_C3)
+
+        # Fourth pipeline
+        cr_C4 = self.store.initialize_empty_component_run("test_component_C")
+        cr_C4.set_start_timestamp()
+        cr_C4.set_end_timestamp()
+        cr_C4.add_inputs([iop[1], iop[2]])
+        cr_C4.add_output(iop[6])
+        self.store.set_dependencies_from_inputs(cr_C4)
+        self.store.commit_component_run(cr_C4)
+
+        # Flag
+        self.store.set_io_pointer_flag("iop_4", True)
+        self.store.set_io_pointer_flag("iop_5", True)
+        self.store.set_io_pointer_flag("iop_6", True)
+        self.store.set_io_pointer_flag("iop_7", True)
+
+        res = self.store.diagnose_flagged_outputs()
+        res = [(cr.component_name, cr.id, count) for cr, count in res]
+        expected_res = [
+            ("test_component_B", 2, 4),
+            ("test_component_A", 1, 4),
+            ("test_component_C", 6, 1),
+            ("test_component_C", 5, 1),
+            ("test_component_C", 4, 1),
+            ("test_component_C", 3, 1),
+        ]
+        self.assertEqual(res, expected_res)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #181 by adding the `diagnose` function to get common ComponentRuns for a set of output ids.

TODO:
- [x] `diagnose` command in CLI
- [x] a more complicated test for `diagnose`