### PR TITLE
Create a second docker-compose file for running docker API & Database containers only

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ If you ran `docker-compose up` from the root directory, you can just navigate to
 
 ![screenshot](./res/trace.png)
 
+### Launch without UI (client-side)
+If you ran `docker-compose docker-compose-not-ui.yml up` from the root directory, you successfully launched database and api containers without the UI so nothing will be displayed in localhost:8080
+
 #### Commands supported in the UI
 
 | Command | Description |

--- a/README.md
+++ b/README.md
@@ -77,9 +77,6 @@ If you ran `docker-compose up` from the root directory, you can just navigate to
 
 ![screenshot](./res/trace.png)
 
-### Launch without UI (client-side)
-If you ran `docker-compose docker-compose-not-ui.yml up` from the root directory, you successfully launched database and api containers without the UI so nothing will be displayed in localhost:8080
-
 #### Commands supported in the UI
 
 | Command | Description |
@@ -92,6 +89,13 @@ If you ran `docker-compose docker-compose-not-ui.yml up` from the root directory
 | `flag OUTPUT_ID` | Flags an output ID for further review. Necessary to see any results from the `review` command. |
 | `unflag OUTPUT_ID` | Unflags an output ID. Removes this output ID from any results from the `review` command. |
 | `review` | Shows a list of output IDs flagged for review and the common component runs involved in producing the output IDs. The component runs are sorted from most frequently occurring to least frequently occurring. |
+
+### Launch without UI (client-side)
+If you want to launch database and api containers without the UI, you will run `docker-compose docker-compose-not-ui.yml up` from the root directory. If running correctly, you should see nothing displayed in the server's IP address at port 8080 (or `localhost:8080`) but the database and API service should work unaffectedly:
+
+1. change directory to the level where docker-compose-not-ui.yml exist (root directory)
+2. run `docker-compose -f docker-compose-not-ui.yml build` to build the image (skip this step if image already exist)
+3. run `docker-compose -f docker-compose-not-ui.yml up` to bring up the service
 
 ### Using the CLI for querying
 

--- a/docker-compose-not-ui.yml
+++ b/docker-compose-not-ui.yml
@@ -1,8 +1,6 @@
 version: '3'
 services:
 
-  
-
   database:
     image: postgres
     volumes:      
@@ -23,6 +21,8 @@ services:
     build:
       context: .
       dockerfile: ./mltrace/server/Dockerfile
+      # dockerfile: ./mltrace/server/Dockerfile
+      # dockerfile: ./mltrace/server/Dockerfile
     environment:
       PYTHONPATH: /src
       DB_URI: "postgresql://admin:admin@database:5432/sqlalchemy"
@@ -31,7 +31,7 @@ services:
     ports:
       - "8000:8000"
     env_file:
-      - ../.flaskenv
+      - ./.flaskenv
     restart: always
     depends_on:
       - database
@@ -39,7 +39,7 @@ services:
       services-network:
         aliases:
           - api
-  
+
 volumes:  
   postgres_data:
 

--- a/mltrace/docker-compose.yml
+++ b/mltrace/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '3'
+services:
+
+  
+
+  database:
+    image: postgres
+    volumes:      
+       - postgres_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+      POSTGRES_DB: sqlalchemy
+    ports:
+      - "5432:5432"
+    restart: always
+    networks:
+      services-network:
+        aliases:
+          - database
+
+  api:
+    build:
+      context: .
+      dockerfile: ./mltrace/server/Dockerfile
+    environment:
+      PYTHONPATH: /src
+      DB_URI: "postgresql://admin:admin@database:5432/sqlalchemy"
+    volumes:
+      - .:/src
+    ports:
+      - "8000:8000"
+    env_file:
+      - ../.flaskenv
+    restart: always
+    depends_on:
+      - database
+    networks:
+      services-network:
+        aliases:
+          - api
+  
+volumes:  
+  postgres_data:
+
+networks:
+  services-network:
+    name: services-network
+    driver: bridge


### PR DESCRIPTION
Closes #168

Change Description:
- created a new docker-compose file  **docker-compose-not-ui.yml**  in the same directory of the original docker-compose file
- Inside the docker-compose-not-ui.yml file, wrote codes to set up two containers Database & API (same code with docker-compose file but code related to UI service removed)

Run the following command to bring up the services:
- ensure changing directory to the level where docker-compose-not-ui.yml exist
- run **docker-compose -f docker-compose-not-ui.yml build** to build the image
- run **docker-compose -f docker-compose-not-ui.yml up** to bring up the service

