### PR TITLE
Adding materialized view creation

### DIFF
--- a/mltrace/db/store.py
+++ b/mltrace/db/store.py
@@ -11,6 +11,7 @@ from mltrace.db.utils import (
     _get_data_and_model_args,
     _load,
     _save,
+    _get_view_name,
 )
 from mltrace.db import (
     Component,
@@ -1070,7 +1071,7 @@ class Store(object):
             .filter(and_(*join_conditions))
         )
 
-        view_name = f"{task_name}_{window_size}_view"
+        view_name = _get_view_name(task_name, window_size)
         str_stmt = stmt.statement.compile(
             compile_kwargs={"literal_binds": True}
         )
@@ -1100,3 +1101,28 @@ class Store(object):
         self.session.execute(trigger_stmt)
 
         self.session.commit()
+
+    def compute_metric_from_view(
+        self,
+        task_name: str,
+        metric_fn: typing.Callable,
+        window_size: int = None,
+    ):
+        """
+        Computes a metric over the specified window (in seconds).
+
+        TODO(shreyashankar): Implement this
+        """
+
+        view_name = _get_view_name(task_name, window_size)
+        stmt = "SELECT * FROM {}".format(view_name)
+        res = self.session.execute(stmt)
+        print(res)
+
+        # Apply the function to each pair of outputs and feedback
+        y_true = [float(out[0]) for out in res]
+        y_pred = [float(out[1]) for out in res]
+
+        # Try computing metric function
+
+        return metric_fn(y_true, y_pred)

--- a/mltrace/db/store.py
+++ b/mltrace/db/store.py
@@ -1112,13 +1112,11 @@ class Store(object):
     ):
         """
         Computes a metric over the specified window (in seconds).
-
-        TODO(shreyashankar): Implement this
         """
 
         view_name = _get_view_name(task_name, window_size)
         stmt = "SELECT feedback_value, output_value FROM {}".format(view_name)
-        res = self.session.execute(stmt)
+        res = self.session.execute(stmt).fetchall()
 
         y_true = []
         y_pred = []

--- a/mltrace/db/store.py
+++ b/mltrace/db/store.py
@@ -25,7 +25,7 @@ from mltrace.db import (
     feedback_table,
 )
 from mltrace.db.models import component_run_output_association
-from sqlalchemy import func, and_, select
+from sqlalchemy import func, and_
 from sqlalchemy.orm import sessionmaker, joinedload
 from sqlalchemy.sql.expression import Tuple
 from sqlalchemy.dialects.postgresql import insert

--- a/mltrace/db/utils.py
+++ b/mltrace/db/utils.py
@@ -1,3 +1,4 @@
+from sqlalchemy.sql.ddl import _DropView
 from mltrace.db.base import Base
 from mltrace.db.models import ComponentRun, PointerTypeEnum
 from sqlalchemy import create_engine
@@ -24,7 +25,7 @@ import typing
 
 
 def _create_engine_wrapper(
-        uri: str, max_retries=5
+    uri: str, max_retries=5
 ) -> sqlalchemy.engine.base.Engine:
     """Creates engine using sqlalchemy API. Includes max retries parameter."""
     retries = 0
@@ -59,6 +60,11 @@ def _drop_everything(engine: sqlalchemy.engine.base.Engine):
     meta = MetaData()
     tables = []
     all_fkeys = []
+
+    for view_name in inspector.get_view_names():
+        con.execute(
+            "DROP MATERIALIZED VIEW IF EXISTS {} CASCADE".format(view_name)
+        )
 
     for table_name in inspector.get_table_names():
         fkeys = []
@@ -172,7 +178,7 @@ def _load(pathname: str, from_client=True) -> typing.Any:
 # TODO(shreyashankar): add cases for other types
 # (e.g., sklearn model, xgboost model, etc)
 def _save(
-        obj, pathname: str = None, var_name: str = "", from_client=True
+    obj, pathname: str = None, var_name: str = "", from_client=True
 ) -> str:
     """Saves joblib object to pathname."""
     if pathname is None:

--- a/mltrace/db/utils.py
+++ b/mltrace/db/utils.py
@@ -1,4 +1,3 @@
-from sqlalchemy.sql.ddl import _DropView
 from mltrace.db.base import Base
 from mltrace.db.models import ComponentRun, PointerTypeEnum
 from sqlalchemy import create_engine

--- a/mltrace/db/utils.py
+++ b/mltrace/db/utils.py
@@ -222,3 +222,8 @@ def _save(
         )
 
     return pathname
+
+
+def _get_view_name(task_name: str, window_size: int) -> str:
+    """Returns the view name for a given task name."""
+    return f"{task_name}_{window_size}_view"

--- a/mltrace/entities/metrics.py
+++ b/mltrace/entities/metrics.py
@@ -55,12 +55,10 @@ class Metric(object):
     def __init__(
         self,
         name: str,
-        compute_freqency: int = 1,
         window_size: int = None,
         fn: typing.Callable = None,
     ):
         self.name = name
-        self.compute_freqency = compute_freqency
         self.window_size = window_size
 
         # Create function
@@ -81,6 +79,4 @@ class Metric(object):
             )
 
     def getIdentifier(self):
-        return (
-            f"{self.name}_freq{self.compute_freqency}_window{self.window_size}"
-        )
+        return f"{self.name}_window{self.window_size}"

--- a/mltrace/entities/task.py
+++ b/mltrace/entities/task.py
@@ -13,6 +13,7 @@ class Task(object):
         # TODO(shreyashankar): Add metric cache
 
     def registerMetric(self, metric: Metric):
+        self.store.create_view(self.task_name, metric.window_size)
         self.metrics.append(metric)
 
         # TODO(shreyashankar) add materialized view for metric

--- a/mltrace/entities/task.py
+++ b/mltrace/entities/task.py
@@ -1,3 +1,4 @@
+from sqlalchemy import exc
 from mltrace import utils as clientUtils
 from mltrace.db import Store
 from mltrace.entities.metrics import get_metric_function, Metric
@@ -12,21 +13,24 @@ class Task(object):
         self.metrics = []
         # TODO(shreyashankar): Add metric cache
 
-    def registerMetric(self, metric: Metric):
-        self.store.create_view(self.task_name, metric.window_size)
+    def registerMetric(self, metric: Metric, create_view: bool = True):
+        if create_view:
+            self.store.create_view(self.task_name, metric.window_size)
         self.metrics.append(metric)
 
-    def computeMetrics(self):
+    def computeMetrics(self, use_views=True):
         results = {}
         for metric in self.metrics:
-            results[
-                metric.getIdentifier()
-            ] = self.store.compute_metric_from_view(
-                self.task_name, metric.fn, window_size=metric.window_size
-            )
-            # results[metric.getIdentifier()] = self.store.compute_metric(
-            #     self.task_name, metric.fn, window_size=metric.window_size
-            # )
+            if use_views:
+                results[
+                    metric.getIdentifier()
+                ] = self.store.compute_metric_from_view(
+                    self.task_name, metric.fn, window_size=metric.window_size
+                )
+            else:
+                results[metric.getIdentifier()] = self.store.compute_metric(
+                    self.task_name, metric.fn, window_size=metric.window_size
+                )
         return results
 
     def logOutput(

--- a/mltrace/entities/task.py
+++ b/mltrace/entities/task.py
@@ -16,14 +16,17 @@ class Task(object):
         self.store.create_view(self.task_name, metric.window_size)
         self.metrics.append(metric)
 
-        # TODO(shreyashankar) add materialized view for metric
-
     def computeMetrics(self):
         results = {}
         for metric in self.metrics:
-            results[metric.getIdentifier()] = self.store.compute_metric(
+            results[
+                metric.getIdentifier()
+            ] = self.store.compute_metric_from_view(
                 self.task_name, metric.fn, window_size=metric.window_size
             )
+            # results[metric.getIdentifier()] = self.store.compute_metric(
+            #     self.task_name, metric.fn, window_size=metric.window_size
+            # )
         return results
 
     def logOutput(

--- a/tests/test_Test.py
+++ b/tests/test_Test.py
@@ -1,72 +1,65 @@
-# import unittest
-# from mltrace import \
-#     Test, \
-#     Component, \
-#     set_db_uri
+import unittest
+from mltrace import Test, Component, set_db_uri
 
 
-# class TestTest(unittest.TestCase):
-#     def setUp(self):
-#         set_db_uri("test")
+class TestTest(unittest.TestCase):
+    def setUp(self):
+        set_db_uri("test")
 
-#     def testRunsAllTestFunc(self):
-#         class DummyTest(Test):
-#             def __init__(self):
-#                 super().__init__("Dummy")
+    def testRunsAllTestFunc(self):
+        class DummyTest(Test):
+            def __init__(self):
+                super().__init__("Dummy")
 
-#             def testCorrect(self, n: list):
-#                 n[0] += 10
-#                 print("testCorrect called")
+            def testCorrect(self, n: list):
+                n[0] += 10
+                print("testCorrect called")
 
-#             def testAlsoCorrect(self, n: list):
-#                 n[0] += 10
-#                 print("testAlsoCorrect called")
+            def testAlsoCorrect(self, n: list):
+                n[0] += 10
+                print("testAlsoCorrect called")
 
-#             def TestNotCorrect(self, n: list):
-#                 raise Exception("TestNotCorrect called!")
+            def TestNotCorrect(self, n: list):
+                raise Exception("TestNotCorrect called!")
 
-#         c = Component(
-#             "aditi",
-#             "test",
-#             "test_description",
-#             afterTests=[DummyTest])
-#         val = [100]
+        c = Component(
+            "aditi", "test", "test_description", afterTests=[DummyTest]
+        )
+        val = [100]
 
-#         @c.run
-#         def function():
-#             n = val
-#             return
+        @c.run
+        def function():
+            n = val
+            return
 
-#         function()
+        function()
 
-#         self.assertTrue(val[0] == 120)
+        self.assertTrue(val[0] == 120)
 
-#     def testRunsOnlyTestFunc(self):
-#         class DummyTest(Test):
-#             def __init__(self):
-#                 super().__init__("Dummy")
+    def testRunsOnlyTestFunc(self):
+        class DummyTest(Test):
+            def __init__(self):
+                super().__init__("Dummy")
 
-#             def testCorrect(self, n: str):
-#                 print("DEBUG: testCorrect called")
+            def testCorrect(self, n: str):
+                print("DEBUG: testCorrect called")
 
-#             def TestNotCorrect(self, n: str):
-#                 raise Exception("TestNotCorrect called!")
+            def TestNotCorrect(self, n: str):
+                raise Exception("TestNotCorrect called!")
 
-#             def notCorrect(self, n: str):
-#                 raise Exception("notCorrect called!")
+            def notCorrect(self, n: str):
+                raise Exception("notCorrect called!")
 
-#             def Test(self, n: str):
-#                 raise Exception("Test called!")
+            def Test(self, n: str):
+                raise Exception("Test called!")
 
-#         c = Component(
-#             "aditi",
-#             "test",
-#             "test_description",
-#             afterTests=[DummyTest])
+        c = Component(
+            "aditi", "test", "test_description", afterTests=[DummyTest]
+        )
 
-#         @c.run
-#         def function():
-#             n = "test"
-#             return
+        @c.run
+        def function():
+            n = "test"
+            return
 
-#         function()
+        function()

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -68,6 +68,6 @@ class TestTask(unittest.TestCase):
             task.logFeedback(random.randint(0, 1), output_id)
 
         for metric in supported_sklearn_metrics:
-            task.registerMetric(Metric(metric))
+            task.registerMetric(Metric(metric), create_view=False)
 
-        task.computeMetrics()
+        task.computeMetrics(use_views=False)


### PR DESCRIPTION
In the `registerMetric` function, create materialized views on joins with relevant window sizes. Also uses these materialized views when computing the metric values.