### PR TITLE
Change vars to filenames.

### DIFF
--- a/examples/dvc-mltrace/01_clean_data.py
+++ b/examples/dvc-mltrace/01_clean_data.py
@@ -10,8 +10,8 @@ c = Component(
 
 
 @c.run(
-    input_vars=["input_filepath"],
-    output_vars=["output_filepath"],
+    input_filenames=["input_filepath"],
+    output_filenames=["output_filepath"],
 )
 def clean(input_filepath: str, output_filepath: str) -> str:
     """

--- a/examples/dvc-mltrace/02_summary_stats.py
+++ b/examples/dvc-mltrace/02_summary_stats.py
@@ -10,7 +10,7 @@ c = Component(
 )
 
 
-@c.run(input_vars=["input_filepath"], output_vars=["output_filepath"])
+@c.run(input_vars=["input_filepath"], output_filenames=["output_filepath"])
 def summary(input_filepath: str, output_filepath: str) -> str:
     """
     print some simple stats about dataset

--- a/examples/industry_ml.py
+++ b/examples/industry_ml.py
@@ -61,7 +61,8 @@ inference_component = Component(
 
 
 @ingest_component.run(
-    input_vars=["client_data_filename"], output_vars=["ingested_data_filename"]
+    input_filenames=["client_data_filename"],
+    output_filenames=["ingested_data_filename"],
 )
 def ingest(client_data_filename: str) -> str:
     # Ingest client's data into our data lake
@@ -70,7 +71,7 @@ def ingest(client_data_filename: str) -> str:
 
 
 @clean_component.run(
-    input_vars=["filename"], output_vars=["clean_data_filename"]
+    input_filenames=["filename"], output_filenames=["clean_data_filename"]
 )
 def clean(filename: str) -> str:
     # Read data into dataframe and clean it
@@ -81,7 +82,7 @@ def clean(filename: str) -> str:
 
 
 @featuregen_component.run(
-    input_vars=["filename"], output_vars=["features_filename"]
+    input_filenames=["filename"], output_filenames=["features_filename"]
 )
 def featuregen(filename: str) -> str:
     # Read data and make features
@@ -92,7 +93,8 @@ def featuregen(filename: str) -> str:
 
 
 @training_component.run(
-    input_vars=["filename", "dev_model"], output_vars=["model_filename"]
+    input_filenames=["filename", "dev_model"],
+    output_filenames=["model_filename"],
 )
 def training(filename: str, dev_model: str = "") -> str:
     # Read data and train model
@@ -106,7 +108,7 @@ def training(filename: str, dev_model: str = "") -> str:
 
 
 @inference_component.run(
-    input_vars=["filename", "model_path"], output_vars=["output_id"]
+    input_filenames=["filename", "model_path"], output_filenames=["output_id"]
 )
 def inference(filename: str, model_path: str) -> str:
     # Load model and data

--- a/examples/new_framework_test.py
+++ b/examples/new_framework_test.py
@@ -21,7 +21,7 @@ _identifier = "".join(random.choice(string.ascii_lowercase) for i in range(10))
 c = PreprocessingComponent("aditi")
 
 
-@c.run(input_vars=["type", "n"], output_vars=["testOutput"])
+@c.run(input_filenames=["type", "n"], output_filenames=["testOutput"])
 def gen_fake_data(
     type: str,
     n: int = 1000,

--- a/examples/research_ml.py
+++ b/examples/research_ml.py
@@ -31,8 +31,8 @@ c = Component(
 
 
 @c.run(
-    input_vars=["lr", "num_epochs", "hidden_size"],
-    output_vars=["model_metric"],
+    input_filenames=["lr", "num_epochs", "hidden_size"],
+    output_filenames=["model_metric"],
 )
 def train_and_evaluate_model(lr, num_epochs, hidden_size):
     # Grab some random accuracy

--- a/examples/stale.py
+++ b/examples/stale.py
@@ -14,8 +14,8 @@ inference_component = Component(
 
 @training_component.run(
     component_name="training",
-    input_vars=["version"],
-    output_vars=["model_file"],
+    input_filenames=["version"],
+    output_filenames=["model_file"],
 )
 def training(version: str) -> str:
     model_file = "model_" + version
@@ -24,8 +24,8 @@ def training(version: str) -> str:
 
 @inference_component.run(
     component_name="inference",
-    input_vars=["model_files"],
-    output_vars=["identifier"],
+    input_filenames=["model_files"],
+    output_filenames=["identifier"],
 )
 def inference(model_files) -> str:
     identifier = "".join(

--- a/examples/tiny.py
+++ b/examples/tiny.py
@@ -23,7 +23,7 @@ c = Component(
 )
 
 
-@c.run(input_vars=["inp_str"], output_vars=["out_str"])
+@c.run(input_filenames=["inp_str"], output_filenames=["out_str"])
 def increment(inp: int) -> int:
     inp_str = f"{_identifier}_{str(inp)}"
     out_str = f"{_identifier}_{str(inp + 1)}"


### PR DESCRIPTION
Closes #293 by changing all the example files args from vars to filenames. This should have been done as part of the refactor in #292 

cc @vishwanath1306 