### PR TITLE
React Routing fixing minor bug localhost:3000 not displaying anything

### DIFF
--- a/mltrace/server/ui/src/App.js
+++ b/mltrace/server/ui/src/App.js
@@ -216,6 +216,9 @@ class App extends Component {
 
     // rerender the website if the url command does not match with current state command
     var urlCommand = window.location.pathname.split("/").filter(str => str !== "");
+    if (urlCommand.length === 0) {
+      this.props.history.push('/recent');
+    }
     if (urlCommand[0] !== this.state.command) {
       this.handleCommand(urlCommand.join(" "));
     }


### PR DESCRIPTION
Closing issue ticket #267

**Bug Description**: When the user click back page several times until the URL ultimately hits "localhost:3000" , the page is not showing anything because the URL does not contain any command. 

**Changes**:
In app.js, put `if (urlCommand.length === 0 ){this.props.history.push('/recent');}`