### PR TITLE
Moving credentials to .env file

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,2 +1,3 @@
 FLASK_APP=mltrace/server/__init__.py
 FLASK_ENV=production
+DB_URI=postgresql://admin:admin@database:5432/sqlalchemy

--- a/.postgresenv
+++ b/.postgresenv
@@ -1,0 +1,3 @@
+POSTGRES_USER=admin
+POSTGRES_PASSWORD=admin
+POSTGRES_DB=sqlalchemy

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ If you are interested in learning about specific `mltrace` concepts, please read
 
 ### Database setup (server-side)
 
-We use Postgres-backed SQLAlchemy. Assuming you have Docker installed, you can run the following commands from the
+First, you will need to create DB credentials. We use Postgres. There is a `.postgresenv` file in the root directory, but you should set your own values for the params.
+
+Assuming you have Docker installed, you can run the following commands from the
 root directory after cloning the most recent release:
 
 ```
@@ -71,6 +73,8 @@ And if you trace this output in the UI (`trace aafknvtoag`), you will get:
 You can also look at `examples` for ways to integrate `mltrace` into your ML pipelines, or check out the [official documentation](https://mltrace.readthedocs.io/en/latest/).
 
 ### Launch UI (client-side)
+
+Double check the Postgres credentials in `.flaskenv` match the credentials set in `.postgresenv`.
 
 If you ran `docker-compose up` from the root directory, you can just navigate to the server's IP address at port 8080 (or `localhost:8080`) in your browser. To launch a dev version of the UI, navigate to `./mltrace/server/ui` and execute `yarn install` then `yarn start`. It should be served at [localhost:3000](localhost:3000). The UI is based on `create-react-app` and [`blueprintjs`](https://blueprintjs.com/docs/). Here's an example of what tracing an output would give:
 

--- a/docker-compose-not-ui.yml
+++ b/docker-compose-not-ui.yml
@@ -3,12 +3,10 @@ services:
 
   database:
     image: postgres
-    volumes:      
-       - postgres_data:/var/lib/postgresql/data
-    environment:
-      POSTGRES_USER: admin
-      POSTGRES_PASSWORD: admin
-      POSTGRES_DB: sqlalchemy
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    env_file:
+      - ./.postgresenv
     ports:
       - "5432:5432"
     restart: always
@@ -21,11 +19,8 @@ services:
     build:
       context: .
       dockerfile: ./mltrace/server/Dockerfile
-      # dockerfile: ./mltrace/server/Dockerfile
-      # dockerfile: ./mltrace/server/Dockerfile
     environment:
       PYTHONPATH: /src
-      DB_URI: "postgresql://admin:admin@database:5432/sqlalchemy"
     volumes:
       - .:/src
     ports:
@@ -40,7 +35,7 @@ services:
         aliases:
           - api
 
-volumes:  
+volumes:
   postgres_data:
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,12 +16,10 @@ services:
 
   database:
     image: postgres
-    volumes:      
-       - postgres_data:/var/lib/postgresql/data
-    environment:
-      POSTGRES_USER: admin
-      POSTGRES_PASSWORD: admin
-      POSTGRES_DB: sqlalchemy
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    env_file:
+      - ./.postgresenv
     ports:
       - "5432:5432"
     restart: always
@@ -36,7 +34,6 @@ services:
       dockerfile: ./mltrace/server/Dockerfile
     environment:
       PYTHONPATH: /src
-      DB_URI: "postgresql://admin:admin@database:5432/sqlalchemy"
     volumes:
       - .:/src
     ports:
@@ -50,8 +47,8 @@ services:
       services-network:
         aliases:
           - api
-  
-volumes:  
+
+volumes:
   postgres_data:
 
 networks:


### PR DESCRIPTION
It is possible to get hacked in the db container. Here we move params to a separate file, which the user should replace with their own secrets.

To protect yourself, change the default parameters in .postgresenv and .flaskenv -- make sure they match.